### PR TITLE
PTY-based spec runner

### DIFF
--- a/guard-motion.gemspec
+++ b/guard-motion.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'guard', '>= 1.1.0'
   gem.add_dependency 'rake',  '>= 0.9'
 
-  gem.add_development_dependency 'bundler',       '~> 1.1.0'
+  gem.add_development_dependency 'bundler',       '>= 1.1.0'
   gem.add_development_dependency 'rspec',         '~> 2.10'
   gem.add_development_dependency 'guard-rspec',   '~> 1.1'
 end

--- a/lib/guard/motion.rb
+++ b/lib/guard/motion.rb
@@ -5,7 +5,8 @@ require 'guard/motion/tasks'
 
 module Guard
   class Motion < Guard
-    autoload :Runner, 'guard/motion/runner'
+    autoload :ResultsParser,  'guard/motion/results_parser'
+    autoload :Runner,         'guard/motion/runner'
 
     # Initialize a Guard.
     # @param [Array<Guard::Watcher>] watchers the Guard file watchers

--- a/lib/guard/motion/results_parser.rb
+++ b/lib/guard/motion/results_parser.rb
@@ -1,0 +1,28 @@
+module Guard
+  class Motion
+    class ResultsParser
+      attr_reader :errors
+      attr_reader :failures
+      attr_reader :specs
+      
+      def parse(output)
+        matched = false
+
+        stats_regex = /(\d+) (tests|specifications),? \(?\d+ (assertions|requirements)\)?, (\d+) failures, (\d+) errors/
+        stats_regex.match(output) do |m|
+          matched = true
+
+          @specs = m[1].to_i
+          @failures = m[4].to_i
+          @errors = m[5].to_i
+        end
+
+        matched
+      end
+
+      def success?
+        errors == 0 && failures == 0
+      end
+    end
+  end
+end

--- a/spec/guard/motion/results_parser_spec.rb
+++ b/spec/guard/motion/results_parser_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+module Guard
+  class Motion
+    describe ResultsParser do
+      describe "#parse" do
+        before do
+          @result = subject.parse(output)
+        end
+
+        context "when the output contains spec output" do
+          context "and specs failed" do
+            let(:output) { ".................FFF...\n18 tests, 21 assertions, 3 failures, 1 errors\n" }
+          
+            it "returns true" do
+              @result.should be_true
+            end
+
+            it "does not consider it successful" do
+              subject.success?.should be_false
+            end
+
+            it "returns the number of tests run" do
+              subject.specs.should == 18
+            end
+
+            it "returns the number of failures" do
+              subject.failures.should == 3
+            end
+
+            it "returns the number of errors" do
+              subject.errors.should == 1
+            end
+          end
+
+          context "and specs passed" do
+            let(:output) { ".................FFF...\n18 tests, 21 assertions, 0 failures, 0 errors\n" }
+
+            it "returns true" do
+              @result.should be_true
+            end
+
+            it "considers the test run successful" do
+              subject.success?.should be_true
+            end
+
+            it "returns the number of tests run" do
+              subject.specs.should == 18
+            end
+
+            it "returns the number of failures" do
+              subject.failures.should == 0
+            end
+
+            it "returns the number of errors" do
+              subject.errors.should == 0
+            end
+          end
+        end
+
+        context "when the output does not contain spec output" do
+          let(:output) { "" }
+
+          it "returns false" do
+            @result.should be_false
+          end
+
+          it "does not consider the test successful" do
+            subject.success?.should be_false
+          end
+
+          it "returns nil for test count" do
+            subject.specs.should_not be
+          end
+
+          it "returns nil for failure count" do
+            subject.failures.should_not be
+          end
+
+          it "returns nil for error count" do
+            subject.errors.should_not be
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull upgrades the `Guard::Motion::Runner` class to run specs using a PTY, rather than simply shelling out. This allows us to capture the output while also streaming it back to the user. The captured output is then parsed for spec success/failure count.
