### PR TITLE
Fix duplicate symbol error when linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.1.1 - September 11, 2012
+
+### Improvements
+
+- Use PTY and parse results for notification (by [@mattgreen](https://github.com/mattgreen))
+
+## 0.1.0 - August 10, 2012
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ end
 ``` ruby
 guard 'motion' do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/[^/]+/(.+)\.rb$})     { |m| "./spec/#{m[1]}_spec.rb" }
+  watch(%r{^lib/[^/]+/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
 end
 ```
 

--- a/lib/guard/motion/runner.rb
+++ b/lib/guard/motion/runner.rb
@@ -16,6 +16,7 @@ module Guard
           paths = all_spec_paths
           message = options[:message] || "Running all specs"
         else
+          paths = uniq_paths(paths)
           message = options[:message] || "Running: #{paths.join(' ')}"
         end
 
@@ -78,6 +79,15 @@ module Guard
         end
 
         output
+      end
+
+      def uniq_paths(paths)
+        full_paths = {}
+        paths.each do |path|
+          full_paths[File.expand_path(path)] ||= path
+        end
+
+        full_paths.values
       end
 
       def all_spec_paths

--- a/lib/guard/motion/templates/Guardfile
+++ b/lib/guard/motion/templates/Guardfile
@@ -2,8 +2,8 @@ guard 'motion' do
   watch(%r{^spec/.+_spec\.rb$})
 
   # RubyMotion App example
-  watch(%r{^app/(.+)\.rb$})     { |m| "./spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.+)\.rb$})           { |m| "spec/#{m[1]}_spec.rb" }
 
   # RubyMotion gem example
-  watch(%r{^lib/[^/]+/(.+)\.rb$})     { |m| "./spec/#{m[1]}_spec.rb" }
+  watch(%r{^lib/[^/]+/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
 end

--- a/lib/guard/motion/version.rb
+++ b/lib/guard/motion/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module MotionVersion
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/spec/guard/motion/runner_spec.rb
+++ b/spec/guard/motion/runner_spec.rb
@@ -48,6 +48,16 @@ module Guard
             subject.run(['something'])
           end
 
+          context 'when two files refer to the same location' do
+            it 'ignores the second file' do
+              PTY.should_receive(:spawn).with(
+                "bundle exec rake spec:specific[\"first\"]"
+              )
+
+              subject.run(['first', './first', 'second/../first'])
+            end
+          end
+
           describe 'notification' do
             context "when the specs fail to execute" do
               let(:output) { "" }


### PR DESCRIPTION
When running specific specs, it was possible for a single spec to be compiled twice, and then linked. The linker would choke on this, claiming a duplicate symbol. This pull fixes that bug by expanding the filename for each path before passing it to the rake spec task.

This was triggered by an incorrect `Guardfile` template included with `guard-motion`. The template was updated, as well as the README. The latter two fixes are not strictly necessary, but are included for completeness.
