### PR TITLE
Add env option to runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ end
 ### List of available options:
 
 ``` ruby
-:bundler => false            # use "bundle exec" to run the rake command, default: true
-:binstubs => true            # use "bin/rake" to run the rake command (takes precedence over :bundle), default: false
-:notification => false       # display Growl (or Libnotify) notification after the specs are done running, default: true
-:all_after_pass => false     # run all specs after changed specs pass, default: true
-:all_on_start => false       # run all the specs at startup, default: true
-:keep_failed => false        # keep failed specs until they pass, default: true
-:spec_paths => ["spec"]      # specify an array of paths that contain spec files
+:bundler => false                 # use "bundle exec" to run the rake command, default: true
+:binstubs => true                 # use "bin/rake" to run the rake command (takes precedence over :bundle), default: false
+:env => {:output => 'test_unit'}  # set env variables to be used by the RubyMotion spec runner, default: {}
+:notification => false            # display Growl (or Libnotify) notification after the specs are done running, default: true
+:all_after_pass => false          # run all specs after changed specs pass, default: true
+:all_on_start => false            # run all the specs at startup, default: true
+:keep_failed => false             # keep failed specs until they pass, default: true
+:spec_paths => ["spec"]           # specify an array of paths that contain spec files
 ```
 
 You can also use a custom binstubs directory using `:binstubs => 'some-dir'`.

--- a/lib/guard/motion/runner.rb
+++ b/lib/guard/motion/runner.rb
@@ -7,6 +7,7 @@ module Guard
         @options = {
           :bundler      => true,
           :binstubs     => false,
+          :env          => {},
           :notification => true,
         }.merge(options)
       end
@@ -54,6 +55,11 @@ module Guard
 
       def rake_command(paths)
         cmd_parts = []
+
+        @options[:env].each do |var, value|
+          cmd_parts << "#{var}=#{value}"
+        end
+
         cmd_parts << "bundle exec" if bundle_exec?
         cmd_parts << rake_executable
         cmd_parts << "spec:specific[\"#{paths.join(';')}\"]"

--- a/spec/guard/motion/runner_spec.rb
+++ b/spec/guard/motion/runner_spec.rb
@@ -86,7 +86,6 @@ module Guard
           end
 
           describe 'options' do
-
             describe ':bundler' do
               context ':bundler => false' do
                 subject { described_class.new(:bundler => false) }
@@ -136,6 +135,18 @@ module Guard
 
                   subject.run(['spec'])
                 end
+              end
+            end
+
+            describe ':env' do
+              subject { described_class.new(:env => { :debug => 1, :output => "test_unit" }) }
+
+              it 'sets environment variables' do
+                PTY.should_receive(:spawn).with(
+                  "debug=1 output=test_unit bundle exec rake spec:specific[\"spec\"]"
+                )
+
+                subject.run(['spec'])
               end
             end
 


### PR DESCRIPTION
This pull adds the ability to set environment variables to be used by the spec runner. The main use of this right now is being able to configure the output style via the `Guardfile`, much like `guard-rspec`.
