### PR TITLE
make Guard::Motion class inherits Guard::Plugin,  instead of deprecated class Guard::Guard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ test/version_tmp
 tmp
 
 .DS_Store
+
+vendor/
+.idea/

--- a/lib/guard/motion.rb
+++ b/lib/guard/motion.rb
@@ -1,5 +1,6 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
+
 
 require 'guard/motion/tasks'
 

--- a/lib/guard/motion.rb
+++ b/lib/guard/motion.rb
@@ -4,15 +4,14 @@ require 'guard/guard'
 require 'guard/motion/tasks'
 
 module Guard
-  class Motion < Guard
+  class Motion < Plugin
     autoload :ResultsParser,  'guard/motion/results_parser'
     autoload :Runner,         'guard/motion/runner'
     autoload :Inspector,      'guard/motion/inspector'
 
     # Initialize a Guard.
-    # @param [Array<Guard::Watcher>] watchers the Guard file watchers
     # @param [Hash] options the custom Guard options
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
       @options = {
         :all_after_pass => true,

--- a/lib/guard/motion/version.rb
+++ b/lib/guard/motion/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module MotionVersion
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end

--- a/spec/guard/motion_spec.rb
+++ b/spec/guard/motion_spec.rb
@@ -33,7 +33,7 @@ module Guard
       it 'creates a runner' do
         described_class::Runner.should_receive(:new).with(default_options.merge(:foo => :bar))
 
-        described_class.new([], :foo => :bar)
+        described_class.new(:foo => :bar)
       end
     end
 
@@ -44,7 +44,7 @@ module Guard
       end
 
       context ':all_on_start option is false' do
-        let(:subject) { subject = described_class.new([], :all_on_start => false) }
+        let(:subject) { subject = described_class.new(:all_on_start => false) }
 
         it "doesn't call #run_all" do
           subject.should_not_receive(:run_all)
@@ -93,7 +93,7 @@ module Guard
         end
 
         context ':all_after_pass option is false' do
-          subject { described_class.new([], :all_after_pass => false) }
+          subject { described_class.new(:all_after_pass => false) }
 
           it "doesn't call #run_all" do
             runner.should_receive(:run).with(['spec/foo']) { false }
@@ -119,7 +119,7 @@ module Guard
       end
 
       it 'keeps failed spec and rerun them later' do
-        subject = described_class.new([], :all_after_pass => false)
+        subject = described_class.new(:all_after_pass => false)
 
         runner.should_receive(:run).with(['spec/bar']) { false }
 


### PR DESCRIPTION
I encontered some "Deprecated" Wargings from Guard gem, so I tried to fix warnings below; 

```
16:47:20 - WARN - Starting with Guard 2.0, Guard::Motion should inherit from Guard::Plugin
> [#] instead of Guard::Guard.
> [#] Please note that the constructor signature has changed from
> [#] Guard::Guard#initialize(watchers = [], options = {}) to
> [#] Guard::Plugin#initialize(options = {}).
> [#] For more information on how to upgrade for Guard 2.0, please head over
> [#] to: https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
> [#]
> [#] Deprecation backtrace: /Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-2.8.2/lib/guard/ui.rb:107:in `deprecation'
> [#]    >/Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-2.8.2/lib/guard/guard.rb:94:in `initialize'
> [#]    >/Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-motion-0.1.2/lib/guard/motion.rb:16:in `initialize'
16:47:20 - INFO - Guard is using TerminalTitle to send notifications.
16:47:20 - INFO - Guard::Motion is running
16:47:20 - INFO - Running all specs

******** BIG DEPRECATION WARNING !! ********

Hi, Guard here.

You're including lib/guard/guard.rb ...

... which contains code deprecated over a year ago!


This file will likely be removed in the next version, so make sure you're
not requiring it anywhere to ensure safe gem upgrades.

If this message is annoying and you can't quickly fix the issue (see below),
you have 2 options:

  1) Simply set the env variable "GUARD_GEM_SILENCE_DEPRECATIONS" to "1" to
  skip this message

  2) Freeze the gem to a previous version (not recommended because upgrades
  are cool and you might forget to unfreeze later!).

  E.g. in your Gemfile:

    if Time.now > Time.new(2014,11,10)
      gem 'guard', '~> 2.8'
    else
      # Freeze until 2014-11-10 - in case we forget to change back ;)
      gem 'guard', '= 2.7.3'
    end

If you don't know which gem or plugin is requiring this file, here's a
backtrace:

/Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-2.8.2/lib/guard/guard.rb:45:in `<module:Guard>'
 >> /Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-2.8.2/lib/guard/guard.rb:3:in `<top (required)>'
 >> /Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-motion-0.1.2/lib/guard/motion.rb:2:in `require'
 >> /Users/yoshi/src/motion/Shuffle100/vendor/bundle/ruby/2.0.0/gems/guard-motion-0.1.2/lib/guard/motion.rb:2:in `<top (required)>'
 >> /Users/yoshi/src/motion/Shuffle100/Rakefile:8:in `require'"

Here's how to quickly upgrade/fix this (given you are a maintainer of the
offending plugin or you want to prepare a pull request yourself):

  https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard

Have fun!

******** END OF DEPRECATION MESSAGE ********
```
